### PR TITLE
fix: admin notification issue in block checkout

### DIFF
--- a/includes/api/v1/class-wpsms-api-send.php
+++ b/includes/api/v1/class-wpsms-api-send.php
@@ -35,7 +35,7 @@ class SendSmsApi extends \WP_SMS\RestApi
         'media_urls'           => array('required' => false, 'type' => 'array'),
         'schedule'             => array('required' => false, 'type' => 'string', 'format' => 'date-time'),
         'repeat'               => array('required' => false, 'type' => 'object'),
-        'notification_handler' => array('required' => false, 'type' => 'string', 'enum' => ['WooCommerceOrderNotification', 'WooCommerceProductNotification', 'WooCommerceCouponNotification', 'WooCommerceCustomerNotification', 'WordPressPostNotification', 'WordPressUserNotification', 'AwesomeSupportTicketNotification', 'WordPressCommentNotification', 'SubscriberNotification']),
+        'notification_handler' => array('required' => false, 'type' => 'string', 'enum' => ['WooCommerceOrderNotification', 'WooCommerceAdminOrderNotification', 'WooCommerceProductNotification', 'WooCommerceCouponNotification', 'WooCommerceCustomerNotification', 'WordPressPostNotification', 'WordPressUserNotification', 'AwesomeSupportTicketNotification', 'WordPressCommentNotification', 'SubscriberNotification']),
         'handler_id'           => array('required' => false, 'type' => 'int'),
     ];
 

--- a/includes/class-wpsms.php
+++ b/includes/class-wpsms.php
@@ -179,6 +179,7 @@ class WP_SMS
         $this->include('src/Notification/Notification.php');
         $this->include('src/Notification/Handler/DefaultNotification.php');
         $this->include('src/Notification/Handler/WooCommerceOrderNotification.php');
+        $this->include('src/Notification/Handler/WooCommerceAdminOrderNotification.php');
         $this->include('src/Notification/Handler/WooCommerceCouponNotification.php');
         $this->include('src/Notification/Handler/WooCommerceCustomerNotification.php');
         $this->include('src/Notification/Handler/WooCommerceProductNotification.php');

--- a/src/Notification/Handler/WooCommerceAdminOrderNotification.php
+++ b/src/Notification/Handler/WooCommerceAdminOrderNotification.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace WP_SMS\Notification\Handler;
+
+class WooCommerceAdminOrderNotification extends WooCommerceOrderNotification
+{
+    protected $order;
+
+    public function __construct($orderId = false)
+    {
+        if ($orderId) {
+            $this->order = wc_get_order($orderId);
+        }
+    }
+}

--- a/src/Notification/NotificationFactory.php
+++ b/src/Notification/NotificationFactory.php
@@ -15,6 +15,7 @@ use WP_SMS\Notification\Handler\WooCommerceCouponNotification;
 use WP_SMS\Notification\Handler\WooCommerceCustomerNotification;
 use WP_SMS\Notification\Handler\AwesomeSupportTicketNotification;
 use WP_SMS\Notification\Handler\FormidableNotification;
+use WP_SMS\Notification\Handler\WooCommerceAdminOrderNotification;
 
 class NotificationFactory
 {
@@ -38,6 +39,15 @@ class NotificationFactory
     public static function getWooCommerceOrder($orderId = false)
     {
         return new WooCommerceOrderNotification($orderId);
+    }
+
+    /**
+     * @param $orderId
+     * @return WooCommerceAdminOrderNotification
+     */
+    public static function getWooCommerceAdminOrder($orderId = false)
+    {
+        return new WooCommerceAdminOrderNotification($orderId);
     }
 
     /**


### PR DESCRIPTION
### Describe your changes
Added a new `WooCommerceAdminOrderNotification` class for admin notifications

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality
