### PR TITLE
Fix login with sms issue

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -169,6 +169,9 @@ WP SMS includes a [Messaging Button](https://wp-sms-pro.com/message-button?utm_s
 * If you have installed the Pro Pack (wp-sms-pro), please make sure that's updated to greater than v3.3
 
 == Changelog ==
+= v6.9.9 - 2024-**-** =
+- **Fix**: Resolved login with sms issue.
+
 = v6.9.8 - 2024-11-24 =
 - **Enhancement**: Updated SMS Point and DirectSend gateways for improved reliability.
 - **Enhancement**: Added support for sending messages with multiple templates for gateway SmsGatewayHub.

--- a/src/Components/NumberParser.php
+++ b/src/Components/NumberParser.php
@@ -190,6 +190,13 @@ class NumberParser
     {
         $selectedCountryCode = Option::getOption('mobile_county_code');
         if (empty($selectedCountryCode)) {
+            if (
+                strpos($this->rawPhoneNumber, '0') === 0 &&
+                substr_count($this->rawPhoneNumber, '0', 0, 2) === 1
+            ) {
+                return $this->rawPhoneNumber;
+            }
+           
             return $phoneNumber;
         }
 


### PR DESCRIPTION
### Describe your changes
Fix the login with SMS issue when the `International Number Input` is empty, and the `Country Code Prefix` is not set

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `readme.txt`.

### Type of change

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208877128293479