### PR TITLE
Preserve new lines in message outbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-= v6.9.10 - 2025-01-22 =
+v6.9.11 - 2025-02-23 =
+- **Fix**: Render New Lines in the Outbox
+- **Fix**: Show Order Items from `%order_items%` Variable in Multiple Lines
+
+v6.9.10 - 2025-01-22 =
 - **New**: Add **Mobile Message Gateway** (Australia).
 - **New**: Add **HelloSMS Gateway** (Sweden).
 - **Fix**: Resolve issues with adding and updating subscriber groups.

--- a/includes/admin/outbox/class-wpsms-outbox.php
+++ b/includes/admin/outbox/class-wpsms-outbox.php
@@ -46,7 +46,7 @@ class Outbox_List_Table extends \WP_List_Table
                 return sprintf(__('%1$s <span class="wpsms-time">%2$s</span>', 'wp-sms'), date_i18n('Y-m-d', strtotime($item[$column_name])), date_i18n('H:i:s', strtotime($item[$column_name])));
 
             case 'message':
-                return $item[$column_name];
+                return nl2br(esc_html($item[$column_name]));
             case 'recipient':
                 $html = '<details>
 						  <summary>' . esc_html__('View more...', 'wp-sms') . '</summary>

--- a/src/Notification/Handler/WooCommerceOrderNotification.php
+++ b/src/Notification/Handler/WooCommerceOrderNotification.php
@@ -179,7 +179,7 @@ class WooCommerceOrderNotification extends Notification
             $preparedItems[] = $itemString;
         }
 
-        return implode('\n', $preparedItems);
+        return implode(PHP_EOL, $preparedItems);
     }
 
     public function getStatus()


### PR DESCRIPTION
### Describe your changes
The order_iems variable returns the items in multiple lines.
The newlines get rendered properly in the Outbox.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `readme.txt`.

### Type of change

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209384887124418