### PR TITLE
feat: Remove "Get All-in-One" action link if license is AIO

### DIFF
--- a/src/Services/Hooks/HooksManager.php
+++ b/src/Services/Hooks/HooksManager.php
@@ -2,6 +2,7 @@
 
 namespace WP_SMS\Services\Hooks;
 
+use WP_SMS\Admin\LicenseManagement\LicenseHelper;
 use WP_SMS\Utils\MenuUtil;
 use WP_SMS\Utils\PluginHelper;
 use WP_SMS\Gateway;
@@ -26,10 +27,16 @@ class HooksManager
      */
     public function addActionLinks($links)
     {
+        $isPremium = (bool) LicenseHelper::isPremiumLicenseAvailable();
+
         $customLinks = [
-            '<a class="wpsms-premium-link-btn" target="_blank" href="https://wp-sms-pro.com/pricing/?utm_source=wp-sms&utm_medium=link&utm_campaign=plugins">' . esc_html__('Get All-in-One', 'wp-sms') . '</a>',
             '<a href="' . MenuUtil::getAdminUrl('settings') . '">' . esc_html__('Settings', 'wp-sms') . '</a>',
         ];
+
+        if (!$isPremium) {
+            $premiumLink = '<a class="wpsms-premium-link-btn" target="_blank" href="https://wp-sms-pro.com/pricing/?utm_source=wp-sms&utm_medium=link&utm_campaign=plugins">' . esc_html__('Get All-in-One', 'wp-sms') . '</a>';
+            array_unshift($customLinks, $premiumLink);
+        }
 
         return array_merge($customLinks, $links);
     }


### PR DESCRIPTION
### Describe your changes
"Get All-in-One" action link is not displayed if license is AIO

Task: https://app.asana.com/1/1198503924754005/project/1208253022496699/task/1210067229569565?focus=true 

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
