### PR TITLE
adding constLicenseValidation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v7.0.1 - 2025-07-** =
 - **Fix:** Properly replace special tags (e.g., %_site_title%) in message content using WPCF7_MailTag to avoid PHP notices and ensure correct output.
 - **Fix:** Corrected handling of multiple phone numbers in Contact Form 7 integration so SMS is sent to all recipients, not just the first one.
 - **Enhancement:** Added user capability checks to AJAX actions in the license manager to restrict access to authorized roles only.
+- **New:** License keys can now be defined in `wp-config.php` using constants (e.g. `WP_SMS_LICENSE`) and will be automatically validated on `init`.
 
 v7.0 - 2025-07-09
 - **New:** Introduced an Onboarding Process to simplify gateway integration.

--- a/src/Admin/LicenseManagement/LicenseManagementManager.php
+++ b/src/Admin/LicenseManagement/LicenseManagementManager.php
@@ -103,8 +103,8 @@ class LicenseManagementManager
                 NoticeManager::getInstance()->registerNotice(
                     'license_validation',
                     sprintf(
-                        esc_html__('Failed to validate license: %s', 'wp-sms'),
-                        esc_html($e->getMessage())
+                        wp_kses_post(__('Failed to validate license: %s', 'wp-sms')),
+                        wp_kses_post($e->getMessage())
                     ),
                     true
                 );

--- a/src/Admin/LicenseManagement/LicenseManagementManager.php
+++ b/src/Admin/LicenseManagement/LicenseManagementManager.php
@@ -8,10 +8,13 @@ use WP_SMS\Admin\LicenseManagement\Plugin\PluginActions;
 use WP_SMS\Admin\LicenseManagement\Plugin\PluginHandler;
 use WP_SMS\Admin\LicenseManagement\Plugin\PluginUpdater;
 use WP_SMS\Components\Assets;
+use WP_SMS\Exceptions\LicenseException;
+use WP_SMS\Notice\NoticeManager;
 use WP_SMS\Utils\Request;
 
 class LicenseManagementManager
 {
+    private $apiCommunicator;
     private $pluginHandler;
     private $handledPlugins = [];
 
@@ -24,11 +27,13 @@ class LicenseManagementManager
 
     public function __construct()
     {
-        $this->pluginHandler = new PluginHandler();
+        $this->apiCommunicator = new ApiCommunicator();
+        $this->pluginHandler   = new PluginHandler();
 
         // Initialize the necessary components.
         $this->initActionCallbacks();
 
+        add_action('init', [$this, 'constLicenseValidation']);
         add_action('init', [$this, 'initPluginUpdaters']);
         add_action('admin_init', [$this, 'showPluginActivationNotice']);
         add_filter('wp_sms_enable_upgrade_to_bundle', [$this, 'showUpgradeToBundle']);
@@ -59,6 +64,55 @@ class LicenseManagementManager
     {
         Assets::script('license-manager', 'js/licenseManager.min.js', ['jquery'], [], true);
     }
+
+    /**
+     * Validates licenses for active plugins using constants defined in wp-config.php.
+     *
+     * This method loops through a list of expected plugin license constants,
+     * and for each active plugin with a defined constant and available license key,
+     * it triggers license validation via the API communicator.
+     *
+     * @return void
+     *
+     * @throws Exception if the API call fails
+     */
+    public function constLicenseValidation(): void
+    {
+        if (!defined('WP_SMS_LICENSE')) {
+            return;
+        }
+
+        $licenses = WP_SMS_LICENSE;
+
+        if (is_string($licenses)) {
+            $licenses = array_map('sanitize_text_field', explode(',', $licenses));
+        } elseif (is_array($licenses)) {
+            $licenses = array_map('sanitize_text_field', $licenses);
+        } else {
+            return;
+        }
+
+        foreach ($licenses as $license) {
+            if (LicenseHelper::getLicenseInfo($license)) {
+                continue; // License is already stored, skip validation
+            }
+
+            try {
+                $this->apiCommunicator->validateLicense($license);
+            } catch (LicenseException $e) {
+                NoticeManager::getInstance()->registerNotice(
+                    'license_validation',
+                    sprintf(
+                        esc_html__('Failed to validate license: %s', 'wp-sms'),
+                        esc_html($e->getMessage())
+                    ),
+                    true
+                );
+                return;
+            }
+        }
+    }
+
 
     public function addMenuItem($items)
     {


### PR DESCRIPTION
### Describe your changes
License keys can now be defined in `wp-config.php` using constants (e.g. `WP_SMS_LICENSE`) and will be automatically validated on `init`.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210925634210697
  - https://app.asana.com/0/0/1210973790437781