### PR TITLE
Fix username collision in SMS registration by appending numeric suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v7.0.1 - 2025-07-** =
 - **Fix:** Properly replace special tags (e.g., %_site_title%) in message content using WPCF7_MailTag to avoid PHP notices and ensure correct output.
 - **Fix:** Corrected handling of multiple phone numbers in Contact Form 7 integration so SMS is sent to all recipients, not just the first one.
 - **Enhancement:** Added user capability checks to AJAX actions in the license manager to restrict access to authorized roles only.
+- **Fix:** Resolved an issue where SMS-based registration would fail if a username generated from a phone number already existed. The username generation logic now appends a numeric suffix to ensure uniqueness, allowing users to re-register with previously used phone numbers without conflict.
 
 v7.0 - 2025-07-09
 - **New:** Introduced an Onboarding Process to simplify gateway integration.

--- a/src/User/UserHelper.php
+++ b/src/User/UserHelper.php
@@ -13,10 +13,17 @@ class UserHelper
      */
     public static function generateHashedUsername($mobileNumber)
     {
-        $hashedMobile = substr(wp_hash(str_replace('+', '', $mobileNumber)), 0, 8);
-        $username     = 'wpsms_' . $hashedMobile;
+        $baseHash     = substr(wp_hash(str_replace('+', '', $mobileNumber)), 0, 8);
+        $baseUsername = 'wpsms_' . $baseHash;
+        $username     = $baseUsername;
+        $i            = 1;
 
-        return apply_filters('wp_sms_registration_username', $username, $mobileNumber);
+        while (username_exists($username)) {
+            $username = $baseUsername . '_' . $i;
+            $i++;
+        }
+
+        return $username;
     }
 
     /**
@@ -163,8 +170,8 @@ class UserHelper
      */
     public static function getLastLogin($userId = false)
     {
-        $userId    = $userId ?: get_current_user_id();
-        $sessions  = get_user_meta($userId, 'session_tokens', true);
+        $userId   = $userId ?: get_current_user_id();
+        $sessions = get_user_meta($userId, 'session_tokens', true);
 
         if (!empty($sessions)) {
             $sessions = array_values($sessions);

--- a/src/User/UserHelper.php
+++ b/src/User/UserHelper.php
@@ -15,8 +15,11 @@ class UserHelper
     {
         $baseHash     = substr(wp_hash(str_replace('+', '', $mobileNumber)), 0, 8);
         $baseUsername = 'wpsms_' . $baseHash;
-        $username     = $baseUsername;
-        $i            = 1;
+
+        $baseUsername = apply_filters('wp_sms_registration_username', $baseUsername, $mobileNumber);
+
+        $username = $baseUsername;
+        $i        = 1;
 
         while (username_exists($username)) {
             $username = $baseUsername . '_' . $i;


### PR DESCRIPTION
### Describe your changes
Resolved an issue where SMS-based registration would fail if a username generated from a phone number already existed. The username generation logic now appends a numeric suffix to ensure uniqueness, allowing users to re-register with previously used phone numbers without conflict.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210854205509616