### PR TITLE
Allow current licence key formats on Add-Ons screen

### DIFF
--- a/src/Admin/LicenseManagement/ApiCommunicator.php
+++ b/src/Admin/LicenseManagement/ApiCommunicator.php
@@ -5,7 +5,6 @@ namespace WP_SMS\Admin\LicenseManagement;
 use Exception;
 use WP_SMS\Components\RemoteRequest;
 use WP_SMS\Exceptions\LicenseException;
-use WP_SMS\Utils\AdminHelper;
 use WP_SMS\Traits\TransientCacheTrait;
 use WP_SMS\Admin\LicenseManagement\Plugin\PluginHelper;
 
@@ -147,7 +146,7 @@ class ApiCommunicator
      */
     public function validateLicense($licenseKey, $product = false)
     {
-        if (empty($licenseKey) || !AdminHelper::isStringLengthBetween($licenseKey, 32, 40) || !preg_match('/^[a-zA-Z0-9-]+$/', $licenseKey)) {
+        if (empty($licenseKey) || !preg_match('/^[a-zA-Z0-9-]+$/', $licenseKey)) {
             throw new LicenseException(
                 esc_html__('License key is not valid. Please enter a valid license and try again.', 'wp-sms'),
                 'invalid_license'

--- a/tests/integration/ApiCommunicatorTest.php
+++ b/tests/integration/ApiCommunicatorTest.php
@@ -6,7 +6,7 @@ use WP_SMS\Admin\LicenseManagement\ApiCommunicator;
 use WP_SMS\Exceptions\LicenseException;
 use WP_UnitTestCase;
 
-class Test_ApiCommunicator extends WP_UnitTestCase
+class ApiCommunicatorTest extends WP_UnitTestCase
 {
     /**
      * @dataProvider supported_license_key_provider

--- a/tests/integration/Test_ApiCommunicator.php
+++ b/tests/integration/Test_ApiCommunicator.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace WP_SMS\Tests\Admin\LicenseManagement;
+
+use WP_SMS\Admin\LicenseManagement\ApiCommunicator;
+use WP_SMS\Exceptions\LicenseException;
+use WP_UnitTestCase;
+
+class Test_ApiCommunicator extends WP_UnitTestCase
+{
+    /**
+     * @dataProvider supported_license_key_provider
+     */
+    public function test_validate_license_contacts_server_for_supported_key_formats($licenseKey)
+    {
+        $requestCount = 0;
+
+        add_filter('pre_http_request', function ($preempt, $parsedArgs, $url) use (&$requestCount, $licenseKey) {
+            $requestCount++;
+
+            $this->assertStringContainsString('/license/status', $url);
+            $this->assertStringContainsString('license_key=' . rawurlencode($licenseKey), $url);
+
+            return [
+                'headers'  => [],
+                'body'     => wp_json_encode([
+                    'status'          => 'valid',
+                    'license_details' => [
+                        'type'        => 'standard',
+                        'sku'         => 'wp-sms-pro',
+                        'max_domains' => 1,
+                        'user'        => 'test@example.com',
+                    ],
+                    'products'        => [],
+                ]),
+                'response' => [
+                    'code'    => 200,
+                    'message' => 'OK',
+                ],
+                'cookies'  => [],
+                'filename' => null,
+            ];
+        }, 10, 3);
+
+        $result = (new ApiCommunicator())->validateLicense($licenseKey);
+
+        $this->assertSame(1, $requestCount);
+        $this->assertSame('valid', $result->status);
+    }
+
+    public function supported_license_key_provider()
+    {
+        return [
+            '16-character key' => ['E0SNWPAPWYTHVPNV'],
+            '32-character key' => [str_repeat('A', 32)],
+            'legacy UUID key'  => ['123e4567-e89b-12d3-a456-426614174000'],
+        ];
+    }
+
+    /**
+     * @dataProvider malformed_license_key_provider
+     */
+    public function test_validate_license_rejects_malformed_keys_without_contacting_server($licenseKey)
+    {
+        $requestCount = 0;
+
+        add_filter('pre_http_request', function () use (&$requestCount) {
+            $requestCount++;
+
+            return new \WP_Error('unexpected_request', 'The license server should not be contacted.');
+        });
+
+        try {
+            (new ApiCommunicator())->validateLicense($licenseKey);
+            $this->fail('Expected malformed license key to be rejected.');
+        } catch (LicenseException $exception) {
+            $this->assertSame('invalid_license', $exception->getStatus());
+        }
+
+        $this->assertSame(0, $requestCount);
+    }
+
+    public function malformed_license_key_provider()
+    {
+        return [
+            'empty key'             => [''],
+            'key containing spaces' => ['INVALID LICENSE KEY'],
+            'key containing symbols' => ['INVALID_KEY!'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- remove the client-side licence-key length restriction
- keep empty-key and allowed-character validation before any request
- add focused coverage for 16-character, 32-character, and legacy UUID keys, plus malformed keys

## Why
The store now issues valid 16-character keys, but the Add-Ons screen rejected anything shorter than 32 characters before contacting the licence server. The server is the authority on key formats, so the client now only rejects empty or obviously malformed values.

## Test plan
- `WP_TESTS_DIR=/tmp/wordpress-tests-lib-1116 WP_TESTS_PHPUNIT_POLYFILLS_PATH=/tmp/phpunit-deps/vendor/yoast/phpunit-polyfills phpunit --testdox tests/integration/ApiCommunicatorTest.php`
- Passes: 6 tests, 18 assertions
- `phpunit --list-tests --filter ApiCommunicatorTest` lists all 6 cases through the default suite configuration

Closes #540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - License validation now accepts valid alphanumeric license keys with hyphens, including shorter and legacy formats.
  - License keys must still be non-empty and contain only supported characters.

- **Bug Fixes**
  - Improved compatibility for valid license keys that were previously rejected because of their length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->