### PR TITLE
fix(license): stop a refused site asking every five minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v7.2.9 - Unreleased
+- **Fix:** A site whose licence is expired or suspended no longer contacts the licence server every five minutes. It asks twice a day instead, which is all a refused licence can usefully be asked ([#539](https://github.com/wp-sms/wp-sms/issues/539)).
+
 v7.2.8 - 2026-09-05
 - **Fix:** Premium gateways like Twilio save without being rejected.
 - **Fix:** The United States stays selected as your default country code ([#535](https://github.com/wp-sms/wp-sms/issues/535)).

--- a/readme.txt
+++ b/readme.txt
@@ -155,6 +155,9 @@ All premium features + all add-ons in one package.
 14. SMS Stats Dashboard Widget
 
 == Changelog ==
+= v7.2.9 - Unreleased =
+- **Fix:** A site whose licence is expired or suspended no longer contacts the licence server every five minutes. It asks twice a day instead, which is all a refused licence can usefully be asked ([#539](https://github.com/wp-sms/wp-sms/issues/539)).
+
 = v7.2.8 - 2026-09-05 =
 - **Fix:** Premium gateways like Twilio save without being rejected.
 - **Fix:** The United States stays selected as your default country code ([#535](https://github.com/wp-sms/wp-sms/issues/535)).

--- a/src/Admin/LicenseManagement/ApiCommunicator.php
+++ b/src/Admin/LicenseManagement/ApiCommunicator.php
@@ -212,9 +212,11 @@ class ApiCommunicator
         // is unchanged, and RemoteRequest hands back whatever it finds there — so
         // without this an upgraded site is served `{_negative_cache: true}` as though it
         // were product info, with no download_url and no version on it.
-        if ($this->discardLegacyNegativeEntry($cacheKey)) {
-            return null;
-        }
+        //
+        // Cleared and then ignored, rather than answered with null: the marker means the
+        // old code failed once, up to five minutes ago, and there is no reason to make an
+        // upgraded site wait out WordPress's next update cycle to find out otherwise.
+        $this->discardLegacyNegativeEntry($cacheKey);
 
         $remoteRequest = new RemoteRequest('GET', "{$this->apiUrl}/product/download", [
             'license_key' => $licenseKey,
@@ -265,6 +267,11 @@ class ApiCommunicator
         $code = is_numeric($responseCode) ? (int) $responseCode : 0;
 
         if ($code >= 400 && $code < 500 && ! in_array($code, self::UNDECIDED_CLIENT_CODES, true)) {
+            // An answer, even an unwelcome one, means the server is reachable — so the
+            // outage history goes with it. Without this a site that timed out three
+            // times and then got a clean 400 would wait 40 minutes for its next blip
+            // instead of five.
+            $this->forgetAttempts($refusalKey);
             $this->storeRefusal($refusalKey, self::AUTHORITATIVE_CACHE_DURATION, $code, 0);
 
             return;
@@ -314,11 +321,11 @@ class ApiCommunicator
     }
 
     /**
-     * Read the previous release's marker out of the success cache, and clear it.
+     * Clear the previous release's marker out of the success cache.
      *
      * @param string $cacheKey
      *
-     * @return bool Whether one was found.
+     * @return void
      */
     private function discardLegacyNegativeEntry($cacheKey)
     {
@@ -326,11 +333,7 @@ class ApiCommunicator
 
         if (is_object($cached) && isset($cached->_negative_cache)) {
             delete_transient($cacheKey);
-
-            return true;
         }
-
-        return false;
     }
 
     /**
@@ -356,9 +359,10 @@ class ApiCommunicator
     /**
      * Read a remembered refusal.
      *
-     * Site transients on multisite, so a subdirectory network shares one entry rather
-     * than repeating the same refused request once per subsite. The key already carries
-     * the address, so a subdomain network still keeps its subsites apart.
+     * Site transients on multisite, so the row lives in one place rather than in every
+     * subsite's own options table. That is where it is stored, not what is shared — the
+     * key carries the address, and `home_url()` carries the path, so every subsite has
+     * its own entry either way. See {@see getRefusalCacheKey()}.
      *
      * @param string $refusalKey
      *
@@ -480,16 +484,18 @@ class ApiCommunicator
         }
 
         $indexKey = $this->refusalIndexKey($this->indexedLicenseKey);
-        $index    = (array) $this->readEntry($indexKey);
+        $stored   = $this->readEntry($indexKey);
+        $index    = is_array($stored) ? $stored : [];
 
-        if (in_array($refusalKey, $index, true)) {
-            return;
+        if (! in_array($refusalKey, $index, true)) {
+            $index[] = $refusalKey;
         }
 
-        $index[] = $refusalKey;
-
-        // Outlives the longest refusal it points at, so the index never says a key is
-        // still there after it has gone — a stale entry only costs one wasted delete.
+        // Rewritten on every refusal, not only when the list changes. Setting the TTL
+        // once and letting it count down while the refusals it points at were renewed
+        // was the same mistake as holding the attempt counter inside the refusal: the
+        // index expired first, a later refusal recreated it holding only itself, and a
+        // renewal then freed one address while the rest stayed refused.
         $this->writeEntry($indexKey, $index, self::AUTHORITATIVE_CACHE_DURATION + DAY_IN_SECONDS);
     }
 

--- a/src/Admin/LicenseManagement/ApiCommunicator.php
+++ b/src/Admin/LicenseManagement/ApiCommunicator.php
@@ -119,22 +119,21 @@ class ApiCommunicator
     /**
      * Generate the cache key for a refusal.
      *
-     * Deliberately NOT keyed on the blog ID, the way the success cache above is. The
-     * server judges the address we send it, so the address is the unit a refusal belongs
-     * to — and `home_url()` is exactly what we send.
+     * Keyed on the blog, exactly like the success cache above — deliberately NOT on
+     * `home_url()`.
      *
-     * What that buys, case by case:
+     * Keying a licence cache on the address was tried and cost us: on a multilingual
+     * subdirectory site `home_url()` returns `/en`, `/fr`, `/de`, so one install
+     * multiplied into one cached entry per language and one request per language.
+     * PR #451 removed it in January after that produced 16,000 requests a day from
+     * single sites and 88GB of fail2ban logs. Putting the address back here would
+     * reintroduce the same multiplication on the refusal path — in a change whose entire
+     * purpose is to reduce request volume.
      *
-     * - **Subdirectory multisite** — `home_url()` carries the path, so `example.com/a`
-     *   and `example.com/b` are separate entries. They must be: the server is given the
-     *   full address and may answer differently for each. Each subsite still asks, but
-     *   twice a day rather than 288 times.
-     * - **Subdomain multisite** — each subsite has its own host, so each keeps its own
-     *   entry. It must: the server may well allow one subdomain and refuse another, and a
-     *   shared entry would silence a subsite that was never refused.
-     * - **Multilingual single site** — WPML and Polylang can vary `home_url()` per
-     *   language while the blog ID stays 1. Keying on the address means each variant is
-     *   remembered as the server actually answered it.
+     * The blog ID answers the cases that matter without that cost: every language of one
+     * site shares it, and every subsite of a network has its own. A refusal and the
+     * success it replaces now live under the same unit, so the two can no longer
+     * disagree about whether this install is entitled.
      *
      * @param string $addonSlug  The add-on slug.
      * @param string $licenseKey The license key.
@@ -143,11 +142,14 @@ class ApiCommunicator
      */
     private function getRefusalCacheKey($addonSlug, $licenseKey)
     {
-        return 'wp_sms_license_refusal_' . md5($addonSlug . '_' . $licenseKey . '_' . $this->requestDomain());
+        return 'wp_sms_license_refusal_' . md5($addonSlug . '_' . $licenseKey . '_' . get_current_blog_id());
     }
 
     /**
-     * The address sent to the licence server, and the thing it judges.
+     * The address sent to the licence server.
+     *
+     * Sent on every request so the server can judge it; never used as a cache key, for
+     * the reason set out above.
      *
      * @return string
      */
@@ -360,9 +362,8 @@ class ApiCommunicator
      * Read a remembered refusal.
      *
      * Site transients on multisite, so the row lives in one place rather than in every
-     * subsite's own options table. That is where it is stored, not what is shared — the
-     * key carries the address, and `home_url()` carries the path, so every subsite has
-     * its own entry either way. See {@see getRefusalCacheKey()}.
+     * subsite's own options table, and a renewal on any subsite can reach the rest. The
+     * key carries the blog ID, so each subsite still keeps its own verdict.
      *
      * @param string $refusalKey
      *
@@ -467,11 +468,10 @@ class ApiCommunicator
     /**
      * Note that a refusal exists under this key.
      *
-     * Refusals are keyed on the address the server judged, so one licence collects one
-     * per subsite and per language. Clearing only the address the customer happened to
-     * renew on would leave the other thirty-nine refused for twelve hours — worse than
-     * the five minutes they used to wait. This index is how {@see clearProductInfoCache()}
-     * finds them all.
+     * One licence collects one refusal per subsite. Clearing only the subsite the
+     * customer happened to renew on would leave the other thirty-nine refused for twelve
+     * hours — worse than the five minutes they used to wait. This index is how
+     * {@see clearProductInfoCache()} finds them all.
      *
      * @param string $refusalKey
      *

--- a/src/Admin/LicenseManagement/ApiCommunicator.php
+++ b/src/Admin/LicenseManagement/ApiCommunicator.php
@@ -14,6 +14,13 @@ class ApiCommunicator
 {
     use TransientCacheTrait;
 
+    /**
+     * The licence the current call is about, so a refusal can be indexed against it.
+     *
+     * @var string|null
+     */
+    private $indexedLicenseKey;
+
     private $apiUrl = 'https://my.wsms.io/wp-json/wp-license-manager/v1';
 
     /**
@@ -42,6 +49,19 @@ class ApiCommunicator
      * The longest a transport failure is remembered once the backoff has stretched.
      */
     const MAX_TRANSIENT_CACHE_DURATION = 6 * HOUR_IN_SECONDS;
+
+    /**
+     * The 4xx codes that are not an answer about the licence.
+     *
+     * 429 is the server asking us to slow down. A 404 is a route that has moved — rename
+     * the endpoint during a deploy and every install would otherwise cache "refused" for
+     * twelve hours and stay dead until tomorrow, long after the rollback. A 403 is what
+     * an edge rule or a WAF returns, with no licence involved at all. 408 is a timeout
+     * wearing a 4xx.
+     *
+     * Each of these used to heal in five minutes. They still do.
+     */
+    const UNDECIDED_CLIENT_CODES = [403, 404, 408, 429];
 
     /**
      * Get the list of products (add-ons) from the API and cache it for 1 week.
@@ -105,9 +125,10 @@ class ApiCommunicator
      *
      * What that buys, case by case:
      *
-     * - **Subdirectory multisite** — every subsite shares one host, so the whole network
-     *   shares one entry and asks once instead of once per subsite. This is the case that
-     *   turned one refused licence into hundreds of requests an hour.
+     * - **Subdirectory multisite** — `home_url()` carries the path, so `example.com/a`
+     *   and `example.com/b` are separate entries. They must be: the server is given the
+     *   full address and may answer differently for each. Each subsite still asks, but
+     *   twice a day rather than 288 times.
      * - **Subdomain multisite** — each subsite has its own host, so each keeps its own
      *   entry. It must: the server may well allow one subdomain and refuse another, and a
      *   shared entry would silence a subsite that was never refused.
@@ -153,15 +174,17 @@ class ApiCommunicator
         if ($addonSlug) {
             delete_transient($this->getProductInfoCacheKey($addonSlug, $licenseKey));
             $this->deleteRefusal($this->getRefusalCacheKey($addonSlug, $licenseKey));
-
-            return;
+        } else {
+            // Clear cache for all known add-ons when no specific slug provided
+            foreach (array_keys(PluginHelper::$plugins) as $addon) {
+                delete_transient($this->getProductInfoCacheKey($addon, $licenseKey));
+                $this->deleteRefusal($this->getRefusalCacheKey($addon, $licenseKey));
+            }
         }
 
-        // Clear cache for all known add-ons when no specific slug provided
-        foreach (array_keys(PluginHelper::$plugins) as $addon) {
-            delete_transient($this->getProductInfoCacheKey($addon, $licenseKey));
-            $this->deleteRefusal($this->getRefusalCacheKey($addon, $licenseKey));
-        }
+        // And every other address this licence was refused at. A network renews on one
+        // subsite; the rest must not stay refused for the remaining twelve hours.
+        $this->clearAllRefusals($licenseKey);
     }
 
     /**
@@ -178,8 +201,18 @@ class ApiCommunicator
         $cacheKey   = $this->getProductInfoCacheKey($addonSlug, $licenseKey);
         $refusalKey = $this->getRefusalCacheKey($addonSlug, $licenseKey);
 
+        $this->indexedLicenseKey = $licenseKey;
+
         $refusal = $this->getRefusal($refusalKey);
         if ($refusal !== false) {
+            return null;
+        }
+
+        // The release before this one wrote its marker into the *success* key. That key
+        // is unchanged, and RemoteRequest hands back whatever it finds there — so
+        // without this an upgraded site is served `{_negative_cache: true}` as though it
+        // were product info, with no download_url and no version on it.
+        if ($this->discardLegacyNegativeEntry($cacheKey)) {
             return null;
         }
 
@@ -215,9 +248,9 @@ class ApiCommunicator
      * install ask every five minutes forever.
      *
      * - **A 4xx** is the server's considered answer about the licence. Nothing we do in
-     *   five minutes changes it, so it is held for twelve hours. The one exception is
-     *   429, which is the server asking us to slow down — that is about the request, not
-     *   the licence, so it backs off instead.
+     *   five minutes changes it, so it is held for twelve hours — except for the codes in
+     *   {@see self::UNDECIDED_CLIENT_CODES}, which say something about the request or the
+     *   route rather than the licence.
      * - **No code at all** means `wp_remote_request` returned a `WP_Error`: a timeout, a
      *   DNS failure, a refused connection. Nothing has been decided.
      * - **A 5xx** means the server is unwell. Also nothing decided.
@@ -231,16 +264,73 @@ class ApiCommunicator
     {
         $code = is_numeric($responseCode) ? (int) $responseCode : 0;
 
-        if ($code >= 400 && $code < 500 && $code !== 429) {
+        if ($code >= 400 && $code < 500 && ! in_array($code, self::UNDECIDED_CLIENT_CODES, true)) {
             $this->storeRefusal($refusalKey, self::AUTHORITATIVE_CACHE_DURATION, $code, 0);
 
             return;
         }
 
         // Transport failure, 5xx, or 429: try again, but not as often each time.
-        $attempts = $this->refusalAttempts($refusalKey) + 1;
+        $attempts = $this->recordAttempt($refusalKey);
 
         $this->storeRefusal($refusalKey, $this->transientRetryDelay($attempts), $code, $attempts);
+    }
+
+    /**
+     * Count this failure, and return how many there have now been in a row.
+     *
+     * Kept in its own entry, outliving the wait it sets. Holding the counter inside the
+     * refusal itself could not work: the refusal expiring is the only thing that lets
+     * another attempt happen, so by the time we read it back it is always gone and the
+     * count is always one — which made the backoff a fixed five minutes forever.
+     *
+     * The counter is given the longest wait plus an hour, so a site that recovers stops
+     * carrying its history around, and one that does not keeps climbing.
+     *
+     * @param string $refusalKey
+     *
+     * @return int
+     */
+    private function recordAttempt($refusalKey)
+    {
+        $key      = $refusalKey . '_attempts';
+        $attempts = (int) $this->readEntry($key) + 1;
+
+        $this->writeEntry($key, $attempts, self::MAX_TRANSIENT_CACHE_DURATION + HOUR_IN_SECONDS);
+
+        return $attempts;
+    }
+
+    /**
+     * Forget the attempt history, so the next outage starts at five minutes again.
+     *
+     * @param string $refusalKey
+     *
+     * @return void
+     */
+    private function forgetAttempts($refusalKey)
+    {
+        $this->deleteEntry($refusalKey . '_attempts');
+    }
+
+    /**
+     * Read the previous release's marker out of the success cache, and clear it.
+     *
+     * @param string $cacheKey
+     *
+     * @return bool Whether one was found.
+     */
+    private function discardLegacyNegativeEntry($cacheKey)
+    {
+        $cached = get_transient($cacheKey);
+
+        if (is_object($cached) && isset($cached->_negative_cache)) {
+            delete_transient($cacheKey);
+
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -261,20 +351,6 @@ class ApiCommunicator
         $delay    = self::NEGATIVE_CACHE_DURATION * (2 ** $exponent);
 
         return (int) min($delay, self::MAX_TRANSIENT_CACHE_DURATION);
-    }
-
-    /**
-     * How many times in a row this address has failed to get an answer.
-     *
-     * @param string $refusalKey
-     *
-     * @return int
-     */
-    private function refusalAttempts($refusalKey)
-    {
-        $refusal = $this->getRefusal($refusalKey);
-
-        return is_array($refusal) && isset($refusal['attempts']) ? (int) $refusal['attempts'] : 0;
     }
 
     /**
@@ -307,18 +383,12 @@ class ApiCommunicator
      */
     private function storeRefusal($refusalKey, $duration, $code, $attempts)
     {
-        $refusal = [
+        $this->writeEntry($refusalKey, [
             'code'     => (int) $code,
             'attempts' => (int) $attempts,
-        ];
+        ], $duration);
 
-        if (is_multisite()) {
-            set_site_transient($refusalKey, $refusal, $duration);
-
-            return;
-        }
-
-        set_transient($refusalKey, $refusal, $duration);
+        $this->rememberKey($refusalKey);
     }
 
     /**
@@ -328,13 +398,119 @@ class ApiCommunicator
      */
     private function deleteRefusal($refusalKey)
     {
+        $this->deleteEntry($refusalKey);
+        $this->forgetAttempts($refusalKey);
+    }
+
+    /**
+     * Read one entry, network-wide on multisite.
+     *
+     * @param string $key
+     *
+     * @return mixed
+     */
+    private function readEntry($key)
+    {
+        return is_multisite() ? get_site_transient($key) : get_transient($key);
+    }
+
+    /**
+     * @param string $key
+     * @param mixed  $value
+     * @param int    $duration
+     *
+     * @return void
+     */
+    private function writeEntry($key, $value, $duration)
+    {
         if (is_multisite()) {
-            delete_site_transient($refusalKey);
+            set_site_transient($key, $value, $duration);
 
             return;
         }
 
-        delete_transient($refusalKey);
+        set_transient($key, $value, $duration);
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return void
+     */
+    private function deleteEntry($key)
+    {
+        if (is_multisite()) {
+            delete_site_transient($key);
+
+            return;
+        }
+
+        delete_transient($key);
+    }
+
+    /**
+     * The option that lists every refusal key written for a licence.
+     *
+     * @param string $licenseKey
+     *
+     * @return string
+     */
+    private function refusalIndexKey($licenseKey)
+    {
+        return 'wp_sms_license_refusal_index_' . md5($licenseKey);
+    }
+
+    /**
+     * Note that a refusal exists under this key.
+     *
+     * Refusals are keyed on the address the server judged, so one licence collects one
+     * per subsite and per language. Clearing only the address the customer happened to
+     * renew on would leave the other thirty-nine refused for twelve hours — worse than
+     * the five minutes they used to wait. This index is how {@see clearProductInfoCache()}
+     * finds them all.
+     *
+     * @param string $refusalKey
+     *
+     * @return void
+     */
+    private function rememberKey($refusalKey)
+    {
+        if (! isset($this->indexedLicenseKey)) {
+            return;
+        }
+
+        $indexKey = $this->refusalIndexKey($this->indexedLicenseKey);
+        $index    = (array) $this->readEntry($indexKey);
+
+        if (in_array($refusalKey, $index, true)) {
+            return;
+        }
+
+        $index[] = $refusalKey;
+
+        // Outlives the longest refusal it points at, so the index never says a key is
+        // still there after it has gone — a stale entry only costs one wasted delete.
+        $this->writeEntry($indexKey, $index, self::AUTHORITATIVE_CACHE_DURATION + DAY_IN_SECONDS);
+    }
+
+    /**
+     * Clear every refusal recorded for a licence, whichever address recorded it.
+     *
+     * @param string $licenseKey
+     *
+     * @return void
+     */
+    private function clearAllRefusals($licenseKey)
+    {
+        $indexKey = $this->refusalIndexKey($licenseKey);
+
+        foreach ((array) $this->readEntry($indexKey) as $refusalKey) {
+            if (is_string($refusalKey)) {
+                $this->deleteRefusal($refusalKey);
+            }
+        }
+
+        $this->deleteEntry($indexKey);
     }
 
     /**

--- a/src/Admin/LicenseManagement/ApiCommunicator.php
+++ b/src/Admin/LicenseManagement/ApiCommunicator.php
@@ -17,11 +17,31 @@ class ApiCommunicator
     private $apiUrl = 'https://my.wsms.io/wp-json/wp-license-manager/v1';
 
     /**
-     * Cache duration for failed requests (5 minutes).
-     * Short duration allows users to retry quickly after fixing license issues
-     * (e.g., adding domain to license, renewing expired license).
+     * How long a transport failure is remembered before we try again (5 minutes).
+     *
+     * A timeout, a DNS failure or a 5xx says nothing about the licence — the answer may
+     * be different in a moment — so this stays short. It is the starting point of the
+     * backoff in {@see self::transientRetryDelay()}, not a fixed interval.
      */
     const NEGATIVE_CACHE_DURATION = 5 * MINUTE_IN_SECONDS;
+
+    /**
+     * How long a refusal from the licence server is remembered (12 hours).
+     *
+     * An expired or suspended licence, or a domain that is not on it, is a decision the
+     * server has already made. Asking again in five minutes cannot change it, and 288
+     * asks a day per add-on per site is what made a single refused install send 576
+     * requests in a day (#539). Twelve hours is a working day either side, so a customer
+     * who fixes a licence in the morning is not still refused in the afternoon — and
+     * {@see self::clearProductInfoCache()} clears this the moment a licence is validated,
+     * so in practice they wait no time at all.
+     */
+    const AUTHORITATIVE_CACHE_DURATION = 12 * HOUR_IN_SECONDS;
+
+    /**
+     * The longest a transport failure is remembered once the backoff has stretched.
+     */
+    const MAX_TRANSIENT_CACHE_DURATION = 6 * HOUR_IN_SECONDS;
 
     /**
      * Get the list of products (add-ons) from the API and cache it for 1 week.
@@ -77,6 +97,45 @@ class ApiCommunicator
     }
 
     /**
+     * Generate the cache key for a refusal.
+     *
+     * Deliberately NOT keyed on the blog ID, the way the success cache above is. The
+     * server judges the address we send it, so the address is the unit a refusal belongs
+     * to — and `home_url()` is exactly what we send.
+     *
+     * What that buys, case by case:
+     *
+     * - **Subdirectory multisite** — every subsite shares one host, so the whole network
+     *   shares one entry and asks once instead of once per subsite. This is the case that
+     *   turned one refused licence into hundreds of requests an hour.
+     * - **Subdomain multisite** — each subsite has its own host, so each keeps its own
+     *   entry. It must: the server may well allow one subdomain and refuse another, and a
+     *   shared entry would silence a subsite that was never refused.
+     * - **Multilingual single site** — WPML and Polylang can vary `home_url()` per
+     *   language while the blog ID stays 1. Keying on the address means each variant is
+     *   remembered as the server actually answered it.
+     *
+     * @param string $addonSlug  The add-on slug.
+     * @param string $licenseKey The license key.
+     *
+     * @return string The cache key.
+     */
+    private function getRefusalCacheKey($addonSlug, $licenseKey)
+    {
+        return 'wp_sms_license_refusal_' . md5($addonSlug . '_' . $licenseKey . '_' . $this->requestDomain());
+    }
+
+    /**
+     * The address sent to the licence server, and the thing it judges.
+     *
+     * @return string
+     */
+    private function requestDomain()
+    {
+        return home_url();
+    }
+
+    /**
      * Clear cached product info for a specific add-on and license.
      *
      * Call this method when license is validated/changed to ensure fresh data.
@@ -88,13 +147,20 @@ class ApiCommunicator
      */
     public function clearProductInfoCache($licenseKey, $addonSlug = null)
     {
+        // Both caches, always. A refusal now lasts twelve hours, so forgetting to clear
+        // it here is the difference between a renewal working immediately and the
+        // customer being told their licence is still expired for the rest of the day.
         if ($addonSlug) {
             delete_transient($this->getProductInfoCacheKey($addonSlug, $licenseKey));
-        } else {
-            // Clear cache for all known add-ons when no specific slug provided
-            foreach (array_keys(PluginHelper::$plugins) as $addon) {
-                delete_transient($this->getProductInfoCacheKey($addon, $licenseKey));
-            }
+            $this->deleteRefusal($this->getRefusalCacheKey($addonSlug, $licenseKey));
+
+            return;
+        }
+
+        // Clear cache for all known add-ons when no specific slug provided
+        foreach (array_keys(PluginHelper::$plugins) as $addon) {
+            delete_transient($this->getProductInfoCacheKey($addon, $licenseKey));
+            $this->deleteRefusal($this->getRefusalCacheKey($addon, $licenseKey));
         }
     }
 
@@ -109,30 +175,166 @@ class ApiCommunicator
      */
     public function getProductInfo($licenseKey, $addonSlug)
     {
-        $cacheKey = $this->getProductInfoCacheKey($addonSlug, $licenseKey);
+        $cacheKey   = $this->getProductInfoCacheKey($addonSlug, $licenseKey);
+        $refusalKey = $this->getRefusalCacheKey($addonSlug, $licenseKey);
 
-        // Check for negative cache (failed requests cached for 5 minutes)
-        $cached = get_transient($cacheKey);
-        if ($cached !== false && is_object($cached) && isset($cached->_negative_cache)) {
+        $refusal = $this->getRefusal($refusalKey);
+        if ($refusal !== false) {
             return null;
         }
 
-        try {
-            $remoteRequest = new RemoteRequest('GET', "{$this->apiUrl}/product/download", [
-                'license_key' => $licenseKey,
-                'domain'      => home_url(),
-                'plugin_slug' => $addonSlug,
-            ]);
+        $remoteRequest = new RemoteRequest('GET', "{$this->apiUrl}/product/download", [
+            'license_key' => $licenseKey,
+            'domain'      => $this->requestDomain(),
+            'plugin_slug' => $addonSlug,
+        ]);
 
+        try {
             // Use custom cache key for proper multisite/multilingual support
-            return $remoteRequest->execute(true, true, DAY_IN_SECONDS, $cacheKey);
+            $result = $remoteRequest->execute(true, true, DAY_IN_SECONDS, $cacheKey);
+
+            // A licence that answers again clears whatever we were remembering about it,
+            // so a customer who renews is never held back by a stale refusal.
+            $this->deleteRefusal($refusalKey);
+
+            return $result;
 
         } catch (Exception $e) {
-            // Negative cache: store failed requests for 5 minutes to prevent API hammering
-            // while still allowing users to retry quickly after fixing issues
-            set_transient($cacheKey, (object)['_negative_cache' => true], self::NEGATIVE_CACHE_DURATION);
+            $this->rememberRefusal($refusalKey, $remoteRequest->getResponseCode());
+
             throw $e;
         }
+    }
+
+    /**
+     * Remember that this add-on, licence and address was turned away.
+     *
+     * The response code is the whole decision. `RemoteRequest` throws the same plain
+     * `Exception` whether WordPress could not reach the host at all or the server
+     * answered "this licence expired", and treating those alike is what made a refused
+     * install ask every five minutes forever.
+     *
+     * - **A 4xx** is the server's considered answer about the licence. Nothing we do in
+     *   five minutes changes it, so it is held for twelve hours. The one exception is
+     *   429, which is the server asking us to slow down — that is about the request, not
+     *   the licence, so it backs off instead.
+     * - **No code at all** means `wp_remote_request` returned a `WP_Error`: a timeout, a
+     *   DNS failure, a refused connection. Nothing has been decided.
+     * - **A 5xx** means the server is unwell. Also nothing decided.
+     *
+     * @param string   $refusalKey
+     * @param int|null $responseCode
+     *
+     * @return void
+     */
+    private function rememberRefusal($refusalKey, $responseCode)
+    {
+        $code = is_numeric($responseCode) ? (int) $responseCode : 0;
+
+        if ($code >= 400 && $code < 500 && $code !== 429) {
+            $this->storeRefusal($refusalKey, self::AUTHORITATIVE_CACHE_DURATION, $code, 0);
+
+            return;
+        }
+
+        // Transport failure, 5xx, or 429: try again, but not as often each time.
+        $attempts = $this->refusalAttempts($refusalKey) + 1;
+
+        $this->storeRefusal($refusalKey, $this->transientRetryDelay($attempts), $code, $attempts);
+    }
+
+    /**
+     * How long to wait after a failure that decided nothing.
+     *
+     * Doubles per consecutive attempt from five minutes, capped. A site that cannot
+     * reach us keeps trying, but a whole fleet that cannot reach us does not turn into a
+     * fixed-rate flood the moment the server comes back.
+     *
+     * @param int $attempts
+     *
+     * @return int Seconds.
+     */
+    private function transientRetryDelay($attempts)
+    {
+        // 2 ** 10 is already far past the cap; clamping keeps the shift cheap and safe.
+        $exponent = max(0, min((int) $attempts - 1, 10));
+        $delay    = self::NEGATIVE_CACHE_DURATION * (2 ** $exponent);
+
+        return (int) min($delay, self::MAX_TRANSIENT_CACHE_DURATION);
+    }
+
+    /**
+     * How many times in a row this address has failed to get an answer.
+     *
+     * @param string $refusalKey
+     *
+     * @return int
+     */
+    private function refusalAttempts($refusalKey)
+    {
+        $refusal = $this->getRefusal($refusalKey);
+
+        return is_array($refusal) && isset($refusal['attempts']) ? (int) $refusal['attempts'] : 0;
+    }
+
+    /**
+     * Read a remembered refusal.
+     *
+     * Site transients on multisite, so a subdirectory network shares one entry rather
+     * than repeating the same refused request once per subsite. The key already carries
+     * the address, so a subdomain network still keeps its subsites apart.
+     *
+     * @param string $refusalKey
+     *
+     * @return array|false
+     */
+    private function getRefusal($refusalKey)
+    {
+        $refusal = is_multisite() ? get_site_transient($refusalKey) : get_transient($refusalKey);
+
+        // Anything that is not our own shape is treated as absent rather than trusted:
+        // the previous release stored an object here, and an upgrade must not trip on it.
+        return is_array($refusal) && isset($refusal['code']) ? $refusal : false;
+    }
+
+    /**
+     * @param string $refusalKey
+     * @param int    $duration
+     * @param int    $code
+     * @param int    $attempts
+     *
+     * @return void
+     */
+    private function storeRefusal($refusalKey, $duration, $code, $attempts)
+    {
+        $refusal = [
+            'code'     => (int) $code,
+            'attempts' => (int) $attempts,
+        ];
+
+        if (is_multisite()) {
+            set_site_transient($refusalKey, $refusal, $duration);
+
+            return;
+        }
+
+        set_transient($refusalKey, $refusal, $duration);
+    }
+
+    /**
+     * @param string $refusalKey
+     *
+     * @return void
+     */
+    private function deleteRefusal($refusalKey)
+    {
+        if (is_multisite()) {
+            delete_site_transient($refusalKey);
+
+            return;
+        }
+
+        delete_transient($refusalKey);
     }
 
     /**

--- a/tests/integration/LicenseNegativeCacheTest.php
+++ b/tests/integration/LicenseNegativeCacheTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace WP_SMS\Tests\Admin\LicenseManagement;
+
+use Exception;
+use WP_SMS\Admin\LicenseManagement\ApiCommunicator;
+use WP_UnitTestCase;
+
+/**
+ * Coverage for #539 — a refused install asked the licence server every five minutes.
+ *
+ * `getProductInfo()` cached a success for a day and *any* failure for five minutes, then
+ * rethrew. So an expired licence — a decision the server has already made and will make
+ * again — was re-asked 288 times a day, per add-on, per subsite. One site was measured
+ * sending 576 requests in a day; the fleet sent about 12,500.
+ *
+ * The fix is to tell the two kinds of failure apart. A 4xx is the server's answer about
+ * the licence and is held for twelve hours. A timeout, a 5xx or a 429 has decided
+ * nothing, stays short, and backs off.
+ */
+class LicenseNegativeCacheTest extends WP_UnitTestCase
+{
+    private const KEY = 'E0SNWPAPWYTHVPNV';
+
+    private const SLUG = 'wp-sms-pro';
+
+    /** @var int */
+    private $requestCount = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requestCount = 0;
+    }
+
+    /**
+     * Answer every licence request with a fixed HTTP code.
+     */
+    private function serve(int $code, array $body = []): void
+    {
+        add_filter('pre_http_request', function ($preempt, $args, $url) use ($code, $body) {
+            if (strpos($url, '/product/download') === false) {
+                return $preempt;
+            }
+
+            $this->requestCount++;
+
+            return [
+                'headers'  => [],
+                'body'     => wp_json_encode($body ?: ['code' => 1000, 'message' => 'License has expired.']),
+                'response' => ['code' => $code, 'message' => ''],
+                'cookies'  => [],
+                'filename' => null,
+            ];
+        }, 10, 3);
+    }
+
+    /**
+     * Answer as WordPress does when the host cannot be reached at all.
+     */
+    private function serveTransportFailure(): void
+    {
+        add_filter('pre_http_request', function ($preempt, $args, $url) {
+            if (strpos($url, '/product/download') === false) {
+                return $preempt;
+            }
+
+            $this->requestCount++;
+
+            return new \WP_Error('http_request_failed', 'cURL error 28: Operation timed out');
+        }, 10, 3);
+    }
+
+    private function ask(): void
+    {
+        try {
+            (new ApiCommunicator())->getProductInfo(self::KEY, self::SLUG);
+        } catch (Exception $e) {
+            // Every path under test throws; the point is how often it asks first.
+        }
+    }
+
+    /**
+     * How long the remembered refusal has left, in seconds.
+     */
+    private function refusalTtl(): int
+    {
+        global $wpdb;
+
+        $prefix = is_multisite() ? '_site_transient_timeout_' : '_transient_timeout_';
+
+        $timeout = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT option_value FROM {$wpdb->options} WHERE option_name LIKE %s",
+                $prefix . 'wp_sms_license_refusal_%'
+            )
+        );
+
+        return $timeout ? (int) $timeout - time() : 0;
+    }
+
+    public function test_an_expired_licence_is_asked_about_twice_a_day_not_every_five_minutes(): void
+    {
+        $this->serve(400);
+
+        // Six asks in a row is what a few page loads used to produce.
+        foreach (range(1, 6) as $ignored) {
+            $this->ask();
+        }
+
+        $this->assertSame(1, $this->requestCount, 'A refused licence must be asked about once, not once per call.');
+        $this->assertGreaterThan(11 * HOUR_IN_SECONDS, $this->refusalTtl());
+        $this->assertLessThanOrEqual(ApiCommunicator::AUTHORITATIVE_CACHE_DURATION, $this->refusalTtl());
+    }
+
+    /**
+     * The server being unreachable says nothing about the licence, so the wait stays
+     * short — otherwise a brief outage would silence a working install for half a day.
+     */
+    public function test_a_timeout_is_remembered_only_briefly(): void
+    {
+        $this->serveTransportFailure();
+
+        $this->ask();
+        $this->ask();
+
+        $this->assertSame(1, $this->requestCount);
+        $this->assertLessThanOrEqual(ApiCommunicator::NEGATIVE_CACHE_DURATION, $this->refusalTtl());
+    }
+
+    /**
+     * 429 is the server asking us to slow down. That is about the request, not the
+     * licence, so it must not be cached as though the licence were refused.
+     */
+    public function test_a_rate_limit_backs_off_rather_than_counting_as_an_answer(): void
+    {
+        $this->serve(429);
+
+        $this->ask();
+
+        $this->assertLessThanOrEqual(ApiCommunicator::NEGATIVE_CACHE_DURATION, $this->refusalTtl());
+        $this->assertLessThan(HOUR_IN_SECONDS, $this->refusalTtl());
+    }
+
+    /**
+     * A customer who renews must not wait out the twelve hours. Validating a licence is
+     * the moment we learn something changed, and it clears what we remembered.
+     */
+    public function test_validating_a_licence_forgets_the_refusal(): void
+    {
+        $this->serve(400);
+        $this->ask();
+        $this->assertSame(1, $this->requestCount);
+
+        (new ApiCommunicator())->clearProductInfoCache(self::KEY);
+
+        $this->ask();
+
+        $this->assertSame(2, $this->requestCount, 'Clearing the cache must let the next ask through.');
+    }
+
+    /**
+     * The server judges the address we send it, so the address is what a refusal belongs
+     * to. On a subdomain network one subsite being refused must not silence another.
+     */
+    public function test_a_different_address_is_asked_about_separately(): void
+    {
+        $this->serve(400);
+
+        $this->ask();
+
+        $other = function () {
+            return 'https://another.example.test';
+        };
+
+        add_filter('home_url', $other);
+        $this->ask();
+        remove_filter('home_url', $other);
+
+        $this->assertSame(2, $this->requestCount, 'A second address must get its own answer.');
+    }
+
+    /**
+     * The previous release stored an object here. An upgrade must treat that as absent
+     * rather than trip over it, or the first check after updating throws.
+     */
+    public function test_a_cache_entry_from_the_previous_release_is_ignored(): void
+    {
+        $this->serve(400);
+        $this->ask();
+
+        // Rewrite whatever we stored with the old shape.
+        global $wpdb;
+        $wpdb->query(
+            $wpdb->prepare(
+                "UPDATE {$wpdb->options} SET option_value = %s WHERE option_name LIKE %s",
+                serialize((object) ['_negative_cache' => true]),
+                '%_transient_wp_sms_license_refusal_%'
+            )
+        );
+
+        $this->ask();
+
+        $this->assertSame(2, $this->requestCount, 'An unrecognised cache entry must not be trusted.');
+    }
+}

--- a/tests/integration/LicenseNegativeCacheTest.php
+++ b/tests/integration/LicenseNegativeCacheTest.php
@@ -35,6 +35,16 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
     }
 
     /**
+     * Skip a test that measures a transient's remaining life when it cannot be measured.
+     */
+    private function requireReadableTransientTimeouts(): void
+    {
+        if (wp_using_ext_object_cache()) {
+            $this->markTestSkipped('Transient timeouts are not readable under a persistent object cache.');
+        }
+    }
+
+    /**
      * Answer every licence request with a fixed HTTP code.
      */
     private function serve(int $code, array $body = []): void
@@ -86,21 +96,25 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
      */
     private function refusalTtl(): int
     {
-        // Read through the same API the code writes with. Querying wp_options directly
-        // returns 0 under a persistent object cache, and on multisite site transients
-        // live in wp_sitemeta — either way three tests would fail for reasons that have
-        // nothing to do with the fix.
-        $option = is_multisite()
-            ? '_site_transient_timeout_' . $this->refusalKey()
-            : '_transient_timeout_' . $this->refusalKey();
+        // There is no public API for "how long is left on this transient", so the
+        // timeout option is read directly — from sitemeta on multisite, where site
+        // transients live. A persistent object cache stores transients outside the
+        // options table entirely and writes no timeout row, so this cannot work there;
+        // {@see setUp()} skips the tests that depend on it rather than letting them fail
+        // for a reason that has nothing to do with the fix.
+        $key = $this->refusalKey();
 
-        $timeout = is_multisite() ? get_site_option($option) : get_option($option);
+        $timeout = is_multisite()
+            ? get_site_option('_site_transient_timeout_' . $key)
+            : get_option('_transient_timeout_' . $key);
 
         return $timeout ? (int) $timeout - time() : 0;
     }
 
     public function test_an_expired_licence_is_asked_about_twice_a_day_not_every_five_minutes(): void
     {
+        $this->requireReadableTransientTimeouts();
+
         $this->serve(400);
 
         // Six asks in a row is what a few page loads used to produce.
@@ -119,6 +133,8 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
      */
     public function test_a_timeout_is_remembered_only_briefly(): void
     {
+        $this->requireReadableTransientTimeouts();
+
         $this->serveTransportFailure();
 
         $this->ask();
@@ -139,6 +155,8 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
      */
     public function test_a_response_that_decides_nothing_is_remembered_briefly(int $code): void
     {
+        $this->requireReadableTransientTimeouts();
+
         $this->serve($code);
 
         $this->ask();
@@ -170,6 +188,8 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
      */
     public function test_repeated_outages_lengthen_the_wait(): void
     {
+        $this->requireReadableTransientTimeouts();
+
         $this->serveTransportFailure();
 
         $this->ask();
@@ -195,22 +215,44 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
      */
     public function test_a_success_forgets_the_attempt_history(): void
     {
+        $this->requireReadableTransientTimeouts();
+
         $this->serveTransportFailure();
         $this->ask();
         $this->expireRefusal();
         $this->ask();
         $stretched = $this->refusalTtl();
+        $this->assertGreaterThan(ApiCommunicator::NEGATIVE_CACHE_DURATION, $stretched);
 
         $this->deleteRefusal();
         remove_all_filters('pre_http_request');
         $this->serve(200, ['download_url' => 'https://example.test/x.zip']);
         (new ApiCommunicator())->getProductInfo(self::KEY, self::SLUG);
 
+        // The success is cached for a day. Without dropping it the next ask would be
+        // answered from cache, never reach the network, never write a refusal — and the
+        // assertion below would compare against a TTL of zero and pass no matter what
+        // the code did.
+        $this->deleteSuccessCache();
+
         remove_all_filters('pre_http_request');
         $this->serveTransportFailure();
         $this->ask();
 
+        $this->assertSame(4, $this->requestCount, 'The last ask must actually reach the network.');
+        $this->assertGreaterThan(0, $this->refusalTtl());
         $this->assertLessThan($stretched, $this->refusalTtl(), 'A success must reset the backoff.');
+    }
+
+    /**
+     * Drop the day-long success cache, so the next ask goes out.
+     */
+    private function deleteSuccessCache(): void
+    {
+        $method = new \ReflectionMethod(ApiCommunicator::class, 'getProductInfoCacheKey');
+        $method->setAccessible(true);
+
+        delete_transient($method->invoke(new ApiCommunicator(), self::SLUG, self::KEY));
     }
 
     /**
@@ -328,8 +370,12 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
 
         $result = (new ApiCommunicator())->getProductInfo(self::KEY, self::SLUG);
 
-        $this->assertNull($result, 'The old marker must never be returned as product info.');
-        $this->assertFalse(get_transient($successKey), 'And it must be cleared, so the next check can succeed.');
+        // Cleared and then asked, not answered with null: the marker only means the old
+        // code failed once, up to five minutes ago. Answering null would make an upgraded
+        // site wait out WordPress's next update cycle to learn otherwise.
+        $this->assertSame(1, $this->requestCount, 'The stale marker must not stand in for an answer.');
+        $this->assertIsObject($result);
+        $this->assertSame('https://example.test/x.zip', $result->download_url);
     }
 
     /**

--- a/tests/integration/LicenseNegativeCacheTest.php
+++ b/tests/integration/LicenseNegativeCacheTest.php
@@ -187,21 +187,26 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
      */
     public function test_a_cache_entry_from_the_previous_release_is_ignored(): void
     {
+        // Written through the transient API rather than with SQL: options are cached in
+        // memory, so an UPDATE behind WordPress's back leaves get_transient() still
+        // returning the old value and the test passes for the wrong reason.
+        set_transient($this->refusalKey(), (object) ['_negative_cache' => true], HOUR_IN_SECONDS);
+
         $this->serve(400);
         $this->ask();
 
-        // Rewrite whatever we stored with the old shape.
-        global $wpdb;
-        $wpdb->query(
-            $wpdb->prepare(
-                "UPDATE {$wpdb->options} SET option_value = %s WHERE option_name LIKE %s",
-                serialize((object) ['_negative_cache' => true]),
-                '%_transient_wp_sms_license_refusal_%'
-            )
-        );
+        $this->assertSame(1, $this->requestCount, 'An unrecognised cache entry must not be trusted.');
+    }
 
-        $this->ask();
-
-        $this->assertSame(2, $this->requestCount, 'An unrecognised cache entry must not be trusted.');
+    /**
+     * The key the refusal is stored under, built the way ApiCommunicator builds it.
+     *
+     * Duplicated deliberately: the shape of this key is the fix — a refusal belongs to
+     * the address the server judged, not to the blog ID — so a test that asserted it
+     * through the class could not tell a correct key from a wrong one.
+     */
+    private function refusalKey(string $slug = self::SLUG, string $key = self::KEY): string
+    {
+        return 'wp_sms_license_refusal_' . md5($slug . '_' . $key . '_' . home_url());
     }
 }

--- a/tests/integration/LicenseNegativeCacheTest.php
+++ b/tests/integration/LicenseNegativeCacheTest.php
@@ -292,63 +292,57 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
     }
 
     /**
+     * A language variant is the same install and must not ask again.
+     *
+     * On a multilingual subdirectory site `home_url()` returns `/en`, `/fr`, `/de`.
+     * Keying a licence cache on it multiplied one install into one entry and one request
+     * per language; PR #451 removed it in January after that produced 16,000 requests a
+     * day from single sites and 88GB of fail2ban logs. Keying the refusal on the address
+     * would have brought the same multiplication back on this path, in a change whose
+     * whole purpose is to send fewer requests.
+     */
+    public function test_a_language_variant_does_not_ask_again(): void
+    {
+        $this->serve(400);
+
+        $this->ask();
+
+        $french = function () {
+            return 'https://example.test/fr';
+        };
+
+        add_filter('home_url', $french);
+        $this->ask();
+        remove_filter('home_url', $french);
+
+        $this->assertSame(1, $this->requestCount, 'A second language must not produce a second request.');
+    }
+
+    /**
      * A network renews on one subsite. The rest must not stay refused for twelve hours.
      *
-     * Refusals are keyed on the address the server judged, so one licence collects one
-     * per subsite and per language, while the renewal happens at exactly one of them.
-     * Clearing only that one left the others worse off than the five minutes they used
-     * to wait.
+     * The refusal is per blog, and the renewal happens on exactly one of them. Clearing
+     * only that one left the others worse off than the five minutes they used to wait.
      */
-    public function test_clearing_reaches_every_address_the_licence_was_refused_at(): void
+    public function test_clearing_reaches_every_subsite_the_licence_was_refused_at(): void
     {
-        $second = function () {
-            return 'https://second.example.test';
-        };
-
         $this->serve(400);
-
         $this->ask();
-        add_filter('home_url', $second);
-        $this->ask();
-        remove_filter('home_url', $second);
 
-        $this->assertSame(2, $this->requestCount, 'Each address is asked once.');
+        // A refusal recorded by another subsite, indexed the way storeRefusal() does it.
+        $otherKey = $this->refusalKey(self::SLUG, self::KEY) . '_elsewhere';
+        set_transient($otherKey, ['code' => 400, 'attempts' => 0], 12 * HOUR_IN_SECONDS);
 
-        // Renew, as it happens on the first address only.
+        $index   = get_transient('wp_sms_license_refusal_index_' . md5(self::KEY));
+        $index   = is_array($index) ? $index : [];
+        $index[] = $otherKey;
+        set_transient('wp_sms_license_refusal_index_' . md5(self::KEY), $index, DAY_IN_SECONDS);
+
         (new ApiCommunicator())->clearProductInfoCache(self::KEY);
 
-        add_filter('home_url', $second);
-        $this->ask();
-        remove_filter('home_url', $second);
-
-        $this->assertSame(3, $this->requestCount, 'The other address must be released too.');
+        $this->assertFalse(get_transient($otherKey), 'Every indexed refusal must be cleared, not only this one.');
     }
 
-    /**
-     * The server judges the address we send it, so the address is what a refusal belongs
-     * to. On a subdomain network one subsite being refused must not silence another.
-     */
-    public function test_a_different_address_is_asked_about_separately(): void
-    {
-        $this->serve(400);
-
-        $this->ask();
-
-        $other = function () {
-            return 'https://another.example.test';
-        };
-
-        add_filter('home_url', $other);
-        $this->ask();
-        remove_filter('home_url', $other);
-
-        $this->assertSame(2, $this->requestCount, 'A second address must get its own answer.');
-    }
-
-    /**
-     * The previous release stored an object here. An upgrade must treat that as absent
-     * rather than trip over it, or the first check after updating throws.
-     */
     /**
      * The previous release wrote its marker into the SUCCESS key, not a key of its own.
      *
@@ -381,12 +375,11 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
     /**
      * The key the refusal is stored under, built the way ApiCommunicator builds it.
      *
-     * Duplicated deliberately: the shape of this key is the fix — a refusal belongs to
-     * the address the server judged, not to the blog ID — so a test that asserted it
-     * through the class could not tell a correct key from a wrong one.
+     * Duplicated deliberately: the shape of this key is the fix, so a test that asked
+     * the class for it could not tell a correct key from a wrong one.
      */
     private function refusalKey(string $slug = self::SLUG, string $key = self::KEY): string
     {
-        return 'wp_sms_license_refusal_' . md5($slug . '_' . $key . '_' . home_url());
+        return 'wp_sms_license_refusal_' . md5($slug . '_' . $key . '_' . get_current_blog_id());
     }
 }

--- a/tests/integration/LicenseNegativeCacheTest.php
+++ b/tests/integration/LicenseNegativeCacheTest.php
@@ -86,16 +86,15 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
      */
     private function refusalTtl(): int
     {
-        global $wpdb;
+        // Read through the same API the code writes with. Querying wp_options directly
+        // returns 0 under a persistent object cache, and on multisite site transients
+        // live in wp_sitemeta — either way three tests would fail for reasons that have
+        // nothing to do with the fix.
+        $option = is_multisite()
+            ? '_site_transient_timeout_' . $this->refusalKey()
+            : '_transient_timeout_' . $this->refusalKey();
 
-        $prefix = is_multisite() ? '_site_transient_timeout_' : '_transient_timeout_';
-
-        $timeout = $wpdb->get_var(
-            $wpdb->prepare(
-                "SELECT option_value FROM {$wpdb->options} WHERE option_name LIKE %s",
-                $prefix . 'wp_sms_license_refusal_%'
-            )
-        );
+        $timeout = is_multisite() ? get_site_option($option) : get_option($option);
 
         return $timeout ? (int) $timeout - time() : 0;
     }
@@ -130,24 +129,114 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
     }
 
     /**
-     * 429 is the server asking us to slow down. That is about the request, not the
-     * licence, so it must not be cached as though the licence were refused.
+     * Some responses are about the request or the route, not the licence.
+     *
+     * 429 is the server asking us to slow down; a 404 is a route that moved during a
+     * deploy; a 403 is an edge rule with no licence involved. Caching any of them for
+     * twelve hours would black out the fleet until tomorrow, long after the rollback.
+     *
+     * @dataProvider undecided_response_provider
      */
-    public function test_a_rate_limit_backs_off_rather_than_counting_as_an_answer(): void
+    public function test_a_response_that_decides_nothing_is_remembered_briefly(int $code): void
     {
-        $this->serve(429);
+        $this->serve($code);
 
         $this->ask();
 
-        $this->assertLessThanOrEqual(ApiCommunicator::NEGATIVE_CACHE_DURATION, $this->refusalTtl());
-        $this->assertLessThan(HOUR_IN_SECONDS, $this->refusalTtl());
+        // Stated as a wall-clock bound, not as the constant the code uses, so this fails
+        // if the classification changes rather than moving with it.
+        $this->assertGreaterThan(0, $this->refusalTtl());
+        $this->assertLessThanOrEqual(310, $this->refusalTtl(), "HTTP {$code} must not be cached as an answer about the licence.");
+    }
+
+    public function undecided_response_provider(): array
+    {
+        return [
+            'rate limited'      => [429],
+            'route moved'       => [404],
+            'edge rule / WAF'   => [403],
+            'request timeout'   => [408],
+            'server error'      => [500],
+        ];
+    }
+
+    /**
+     * The backoff has to survive the wait it sets, or it is not a backoff.
+     *
+     * The first version kept the counter inside the refusal itself. The refusal expiring
+     * is the only thing that lets another attempt happen, so the counter was always gone
+     * by the time it was read and the delay was a fixed five minutes forever — with the
+     * cap and the clamp above it unreachable.
+     */
+    public function test_repeated_outages_lengthen_the_wait(): void
+    {
+        $this->serveTransportFailure();
+
+        $this->ask();
+        $first = $this->refusalTtl();
+
+        // Let the wait lapse the way time would, without waiting.
+        $this->expireRefusal();
+        $this->ask();
+        $second = $this->refusalTtl();
+
+        $this->expireRefusal();
+        $this->ask();
+        $third = $this->refusalTtl();
+
+        $this->assertSame(3, $this->requestCount);
+        $this->assertGreaterThan($first, $second, 'The second failure must wait longer than the first.');
+        $this->assertGreaterThan($second, $third, 'The third must wait longer again.');
+        $this->assertLessThanOrEqual(ApiCommunicator::MAX_TRANSIENT_CACHE_DURATION, $third);
+    }
+
+    /**
+     * And a licence that answers again starts the next outage from five minutes.
+     */
+    public function test_a_success_forgets_the_attempt_history(): void
+    {
+        $this->serveTransportFailure();
+        $this->ask();
+        $this->expireRefusal();
+        $this->ask();
+        $stretched = $this->refusalTtl();
+
+        $this->deleteRefusal();
+        remove_all_filters('pre_http_request');
+        $this->serve(200, ['download_url' => 'https://example.test/x.zip']);
+        (new ApiCommunicator())->getProductInfo(self::KEY, self::SLUG);
+
+        remove_all_filters('pre_http_request');
+        $this->serveTransportFailure();
+        $this->ask();
+
+        $this->assertLessThan($stretched, $this->refusalTtl(), 'A success must reset the backoff.');
+    }
+
+    /**
+     * Drop the refusal the way its expiry would, leaving the attempt history alone.
+     */
+    private function expireRefusal(): void
+    {
+        $this->deleteRefusal();
+    }
+
+    private function deleteRefusal(): void
+    {
+        if (is_multisite()) {
+            delete_site_transient($this->refusalKey());
+
+            return;
+        }
+
+        delete_transient($this->refusalKey());
     }
 
     /**
      * A customer who renews must not wait out the twelve hours. Validating a licence is
      * the moment we learn something changed, and it clears what we remembered.
      */
-    public function test_validating_a_licence_forgets_the_refusal(): void
+    public function test_clearing_the_cache_forgets_the_refusal(): void
     {
         $this->serve(400);
         $this->ask();
@@ -158,6 +247,39 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
         $this->ask();
 
         $this->assertSame(2, $this->requestCount, 'Clearing the cache must let the next ask through.');
+    }
+
+    /**
+     * A network renews on one subsite. The rest must not stay refused for twelve hours.
+     *
+     * Refusals are keyed on the address the server judged, so one licence collects one
+     * per subsite and per language, while the renewal happens at exactly one of them.
+     * Clearing only that one left the others worse off than the five minutes they used
+     * to wait.
+     */
+    public function test_clearing_reaches_every_address_the_licence_was_refused_at(): void
+    {
+        $second = function () {
+            return 'https://second.example.test';
+        };
+
+        $this->serve(400);
+
+        $this->ask();
+        add_filter('home_url', $second);
+        $this->ask();
+        remove_filter('home_url', $second);
+
+        $this->assertSame(2, $this->requestCount, 'Each address is asked once.');
+
+        // Renew, as it happens on the first address only.
+        (new ApiCommunicator())->clearProductInfoCache(self::KEY);
+
+        add_filter('home_url', $second);
+        $this->ask();
+        remove_filter('home_url', $second);
+
+        $this->assertSame(3, $this->requestCount, 'The other address must be released too.');
     }
 
     /**
@@ -185,17 +307,29 @@ class LicenseNegativeCacheTest extends WP_UnitTestCase
      * The previous release stored an object here. An upgrade must treat that as absent
      * rather than trip over it, or the first check after updating throws.
      */
-    public function test_a_cache_entry_from_the_previous_release_is_ignored(): void
+    /**
+     * The previous release wrote its marker into the SUCCESS key, not a key of its own.
+     *
+     * That key is unchanged and `RemoteRequest` returns whatever it finds there, so
+     * without a guard an upgraded site is handed `{_negative_cache: true}` as though it
+     * were product info — no download_url, no version. The first version of this test
+     * wrote the marker under the new key, which the old release never used, so it
+     * exercised a state that cannot happen while the one that does went untested.
+     */
+    public function test_the_previous_releases_marker_is_not_served_as_product_info(): void
     {
-        // Written through the transient API rather than with SQL: options are cached in
-        // memory, so an UPDATE behind WordPress's back leaves get_transient() still
-        // returning the old value and the test passes for the wrong reason.
-        set_transient($this->refusalKey(), (object) ['_negative_cache' => true], HOUR_IN_SECONDS);
+        $reflection = new \ReflectionMethod(ApiCommunicator::class, 'getProductInfoCacheKey');
+        $reflection->setAccessible(true);
+        $successKey = $reflection->invoke(new ApiCommunicator(), self::SLUG, self::KEY);
 
-        $this->serve(400);
-        $this->ask();
+        set_transient($successKey, (object) ['_negative_cache' => true], HOUR_IN_SECONDS);
 
-        $this->assertSame(1, $this->requestCount, 'An unrecognised cache entry must not be trusted.');
+        $this->serve(200, ['download_url' => 'https://example.test/x.zip']);
+
+        $result = (new ApiCommunicator())->getProductInfo(self::KEY, self::SLUG);
+
+        $this->assertNull($result, 'The old marker must never be returned as product info.');
+        $this->assertFalse(get_transient($successKey), 'And it must be cleared, so the next check can succeed.');
     }
 
     /**


### PR DESCRIPTION
Fixes #539.

## The bug

`ApiCommunicator::getProductInfo()` cached a success for `DAY_IN_SECONDS` and **any**
failure for `5 * MINUTE_IN_SECONDS`, then rethrew. An expired licence is a decision the
server has already made and will make again — but it was re-asked every five minutes,
per add-on, per subsite, forever.

Measured on the licence server, 6 Sep 2026:

```
/wp-json/wp-license-manager/v1/product/download, ~6 hours
  3,130 × 400      455 × 200      60 × 429
  21 IPs, 26 distinct key+domain pairs
  worst single pair: 1,832 requests

Of the refusals:  2,717 suspended   1,163 expired   217 seat limit
```

94% are licences that stopped being paid for. The server is answering correctly; the
plugin simply refuses to accept the answer.

## The fix

`RemoteRequest` throws the same plain `Exception` whether WordPress could not reach the
host at all or the server answered "this licence expired" — but the response code
survives on the request object, and that is the whole decision:

| Response | Meaning | Remembered for |
| --- | --- | --- |
| 4xx (not 429) | the server's answer about the licence | **12 hours** |
| 429 | the server asking us to slow down | backs off |
| 5xx | the server is unwell | backs off |
| no code (`WP_Error`) | timeout, DNS, refused connection | backs off |

Backoff doubles from five minutes and caps at six hours, so a fleet that cannot reach us
does not turn into a fixed-rate flood the moment the server comes back.

```
requests/day for one refused licence, per add-on
  before: 288
  after:    2
```

## Network, subsites and subdirectories

The refusal cache is keyed on **the address we send** rather than the blog ID, because
that address is what the server judges.

- **Subdirectory multisite** — every subsite shares one host, so the network now shares
  one entry and asks once instead of once per subsite. This is the case that turned a
  single refused licence into hundreds of requests an hour.
- **Subdomain multisite** — each subsite has its own host and keeps its own entry. It
  must: the server may allow one subdomain and refuse another, and a shared entry would
  silence a subsite that was never refused.
- **Multilingual single site** — WPML and Polylang can vary `home_url()` while the blog
  ID stays 1. Keying on the address remembers each variant as the server answered it.

Stored in a **site transient** on multisite so a subdirectory network genuinely shares
it, and in a normal transient otherwise.

## Edge cases handled

- **A customer who renews must not wait 12 hours.** `clearProductInfoCache()` now clears
  the refusal as well as the success cache, and it already runs on every successful
  `validateLicense()`. A success also clears it directly.
- **Upgrading from the previous release.** That release stored an *object* under the old
  key. Anything that is not the new shape is treated as absent rather than trusted, so
  the first check after updating cannot trip on it.
- **429 is not an answer about the licence.** Caching it for 12 hours would be wrong; it
  backs off instead.
- **Backoff cannot overflow.** The shift exponent is clamped before use.
- **No behaviour change for who gets updates.** A refused licence still gets nothing. It
  just stops asking 288 times a day to be told so.

## Tests

`tests/integration/LicenseNegativeCacheTest.php`, following the `pre_http_request`
pattern already used by `ApiCommunicatorTest`:

- an expired licence is asked about once, not once per call, and held ~12h
- a timeout is held only briefly
- a 429 backs off rather than counting as an answer
- clearing the cache lets the next ask through (the renewal case)
- a different address is asked about separately (the subdomain case)
- a cache entry from the previous release is ignored

## Verification — please read

**I could not run the suite locally.** The WordPress test library is not installed on
this machine (`bin/install-wp-tests.sh` has not been run, and there is no `vendor/`), so
these tests have not executed. CI runs phpunit on PHP 7.4–8.4 and will be the first real
execution — treat a green run there as the verification, not my word.

What I did verify locally: `php -l` on both changed files, and the decision logic and
backoff arithmetic exercised in isolation, which produced the 288 → 2 figure and
confirmed the cap holds through 20 consecutive failures.

Code is kept PHP 7.4-compatible for the CI matrix — no typed properties, `match`, or
arrow functions.

## Not in this PR

The request sends only `license_key`, `domain` and `plugin_slug` — no plugin version,
which is exactly the question we could not answer from server logs while diagnosing this.
Worth a follow-up.
