### PR TITLE
Send subscription validation errors as plain text, not HTML-escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 v7.2.9 - Unreleased
+- **Fix:** Subscription validation errors no longer show HTML entities, so an apostrophe reaches the visitor as an apostrophe ([#547](https://github.com/wp-sms/wp-sms/issues/547)).
 - **Fix:** A site whose licence is expired or suspended no longer contacts the licence server every five minutes. It asks twice a day instead, which is all a refused licence can usefully be asked ([#539](https://github.com/wp-sms/wp-sms/issues/539)).
 
 v7.2.8 - 2026-09-05

--- a/src/Controller/PublicSubscribeAjax.php
+++ b/src/Controller/PublicSubscribeAjax.php
@@ -43,22 +43,45 @@ class PublicSubscribeAjax extends AjaxControllerAbstract
         $result = SubscriberUtil::subscribe($name, $number, $group_id, $customFields);
 
         if (is_wp_error($result)) {
-            $errorData = $result->get_error_data();
-            $actions   = self::sanitizeValidationActions(
-                is_array($errorData) && isset($errorData['actions']) ? $errorData['actions'] : array()
-            );
+            $payload = self::formatValidationError($result);
 
-            if ($actions) {
-                wp_send_json_error(array(
-                    'message' => esc_html($result->get_error_message()),
-                    'actions' => $actions,
-                ), 400);
+            if (is_array($payload)) {
+                wp_send_json_error($payload, 400);
             }
 
-            throw new Exception(esc_html($result->get_error_message()));
+            throw new Exception($payload);
         }
 
         return wp_send_json_success($result);
+    }
+
+    /**
+     * Turn a subscription validation error into what the form's JavaScript renders.
+     *
+     * The message is sent as plain text, not HTML-escaped: the frontend puts it in
+     * the page with jQuery's .text(), which escapes on its own. Escaping here as
+     * well used to double it, so an apostrophe reached the visitor as &#039;.
+     *
+     * @param \WP_Error $error
+     *
+     * @return string|array The message alone, or message plus validated actions.
+     */
+    public static function formatValidationError(\WP_Error $error)
+    {
+        $message   = (string) $error->get_error_message();
+        $errorData = $error->get_error_data();
+        $actions   = self::sanitizeValidationActions(
+            is_array($errorData) && isset($errorData['actions']) ? $errorData['actions'] : array()
+        );
+
+        if ($actions) {
+            return array(
+                'message' => $message,
+                'actions' => $actions,
+            );
+        }
+
+        return $message;
     }
 
     /**

--- a/tests/unit/SubscriptionValidationActionTest.php
+++ b/tests/unit/SubscriptionValidationActionTest.php
@@ -80,4 +80,42 @@ class SubscriptionValidationActionTest extends WP_UnitTestCase
             ),
         ), $actions);
     }
+
+    public function testMessageIsSentAsPlainTextForTheFrontendToEscape()
+    {
+        $plain = PublicSubscribeAjax::formatValidationError(
+            new \WP_Error('opted_out', "You're unsubscribed & can't rejoin yet.")
+        );
+
+        $this->assertSame("You're unsubscribed & can't rejoin yet.", $plain);
+
+        $withActions = PublicSubscribeAjax::formatValidationError(
+            new \WP_Error('opted_out', "You're unsubscribed. Text START to rejoin.", array(
+                'actions' => array(
+                    array('label' => 'Text START', 'href' => 'sms:+15555554567?body=START'),
+                    array('label' => 'Bad', 'href' => 'javascript:alert(1)'),
+                ),
+            ))
+        );
+
+        $this->assertSame(array(
+            'message' => "You're unsubscribed. Text START to rejoin.",
+            'actions' => array(
+                array(
+                    'label' => 'Text START',
+                    'href'  => 'sms:+15555554567?body=START',
+                    'type'  => 'sms',
+                ),
+            ),
+        ), $withActions);
+    }
+
+    public function testRawHtmlInTheMessageIsNeitherRenderedNorDoubleEscaped()
+    {
+        // Left as-is: the frontend shows it literally, which tells the developer
+        // to move the link into the actions array instead of the message.
+        $message = 'Unsubscribed.<br><a href="sms:+1?body=START">Text START</a>';
+
+        $this->assertSame($message, PublicSubscribeAjax::formatValidationError(new \WP_Error('opted_out', $message)));
+    }
 }


### PR DESCRIPTION
Closes #547.

## What
`PublicSubscribeAjax` no longer runs `esc_html()` on a subscription validation message. Both response shapes (message plus `actions`, and the plain `Exception` path) now carry the message as written. The formatting moved into `PublicSubscribeAjax::formatValidationError(WP_Error)` so it can be unit-tested without the AJAX plumbing.

## Why
#534 switched `blocks.js` from `.html()` to `.text()` for the error, which escapes on its own. The server-side `esc_html()` was left from the `.html()` days, so the visitor saw both escapes: `You're` became `You&#039;re`, `&` became `&amp;`.

Raw HTML in a message stays literal on purpose (the form shows `<br>` as text). That is the signal to a developer that the link belongs in the `actions` array, and it is what surfaced the customer case behind #533.

## Verified
- `phpunit tests/unit/SubscriptionValidationActionTest.php` against the WordPress test library: 4 tests, 5 assertions, green. Two new tests cover the apostrophe/ampersand message with and without actions, and the literal-HTML case.
- No JavaScript change; the frontend bundle is untouched.
